### PR TITLE
Implement alloy-inspired voice assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.wav
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,95 @@
-# My First Codex Project
+# Alloy Voice Assistant (Inspired)
 
-This is a starter repository for experimenting with **OpenAI Codex**.
+This repository implements a lightweight, microphone-driven voice assistant inspired by [svpino/alloy-voice-assistant](https://github.com/svpino/alloy-voice-assistant). It demonstrates how to combine OpenAI's transcription, reasoning, and text-to-speech capabilities to hold natural conversations using the "Alloy" voice.
 
-## Notes
-- This repo was initialized to test Codex integration.
-- Future commits will add real code and configuration.
+## Features
+
+- 🎙️ **Hands-free conversations** – capture speech from your default microphone with automatic silence detection.
+- 🤖 **Conversational context** – maintain a rolling dialogue history so Alloy can give relevant follow-up answers.
+- 🗣️ **Voice responses** – request synthesized speech from OpenAI's text-to-speech models and play it back locally.
+- ⚙️ **Configurable runtime** – override models, sampling parameters, and prompts via environment variables.
+- ✅ **Tested utilities** – includes unit tests for configuration parsing, conversation memory, and message assembly.
+
+## Requirements
+
+- Python 3.10+
+- An OpenAI API key with access to GPT-4o models
+- A working microphone (for recording) and speakers/headphones (for playback)
+
+Install the runtime dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+> **Note:** Audio capture requires `sounddevice` (PortAudio). On Linux you may need to install system packages such as `libportaudio2` before installing Python dependencies.
+
+## Configuration
+
+Set the required API key and optional overrides in your shell before launching the assistant:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | **Required.** Your OpenAI API key. | — |
+| `ALLOY_MODEL` | Model used for reasoning responses. | `gpt-4o-mini` |
+| `ALLOY_TRANSCRIPTION_MODEL` | Model used for speech-to-text. | `gpt-4o-mini-transcribe` |
+| `ALLOY_TTS_MODEL` | Model used for text-to-speech. | `gpt-4o-mini-tts` |
+| `ALLOY_VOICE` | Voice name for synthesized audio. | `alloy` |
+| `ALLOY_SAMPLE_RATE` | Microphone sample rate. | `16000` |
+| `ALLOY_BLOCK_DURATION` | Length (seconds) of audio chunks captured per buffer. | `0.5` |
+| `ALLOY_SILENCE_THRESHOLD` | RMS threshold below which audio counts as silence. | `0.015` |
+| `ALLOY_MAX_SILENCE` | How long (seconds) of silence ends a recording. | `1.5` |
+| `ALLOY_MAX_RECORDING` | Hard limit (seconds) for a single utterance. | `30.0` |
+| `ALLOY_MIN_RECORDING` | Minimum duration (seconds) before silence ends the capture. | `0.4` |
+| `ALLOY_CONVERSATION_WINDOW` | Number of recent messages to retain in memory. | `8` |
+| `ALLOY_SYSTEM_PROMPT` | System prompt used to steer Alloy's personality. | Helpful Alloy prompt |
+
+## Usage
+
+Activate your environment and run the module:
+
+```bash
+python -m alloy_assistant
+```
+
+- Press **Enter** to begin recording. Speak naturally and pause; the recorder automatically stops after a short silence.
+- Alloy prints the transcript, generates a response, and (if `simpleaudio` is installed) plays synthesized speech back.
+- Type `quit`, `q`, or `exit` to leave the session.
+
+To hide the ASCII art banner:
+
+```bash
+python -m alloy_assistant --no-banner
+```
+
+## Running tests
+
+Run the bundled unit tests with Python's built-in unittest discovery:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+```
+
+## Project structure
+
+```
+├── pyproject.toml          # Packaging metadata and dependencies
+├── src/alloy_assistant     # Application source code
+│   ├── assistant.py        # CLI entry point and runtime loop
+│   ├── audio.py            # Microphone recorder and audio playback helpers
+│   ├── client.py           # OpenAI client wrapper + message builder
+│   ├── config.py           # Environment-driven configuration values
+│   ├── conversation.py     # Rolling conversation memory utilities
+│   └── __main__.py         # Enables `python -m alloy_assistant`
+└── tests                   # Unit tests for core helpers
+```
+
+## Troubleshooting
+
+- **No microphone detected:** ensure `sounddevice` is installed and your OS exposes a default input device. Running `python -m sounddevice` can help diagnose driver issues.
+- **No audio playback:** install `simpleaudio` or disable playback (responses will still be printed).
+- **API errors:** verify your OpenAI quota and that the configured models are available to your API key.
+
+Have fun building on top of this foundation! Feel free to adapt the assistant's prompt, expand the UI, or integrate home-automation commands just like the original Alloy project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "alloy-voice-assistant"
+version = "0.1.0"
+description = "A lightweight voice assistant inspired by the alloy-voice-assistant project"
+readme = "README.md"
+authors = [
+  {name = "OpenAI Codex User"}
+]
+requires-python = ">=3.10"
+dependencies = [
+  "openai>=1.35.3",
+  "numpy>=1.26.0",
+  "sounddevice>=0.4.6",
+  "simpleaudio>=1.0.4"
+]
+
+
+[project.urls]
+Homepage = "https://github.com/svpino/alloy-voice-assistant"
+Repository = "https://github.com/svpino/alloy-voice-assistant"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/alloy_assistant/__init__.py
+++ b/src/alloy_assistant/__init__.py
@@ -1,0 +1,16 @@
+"""Alloy-inspired voice assistant package."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Lazy entry point that defers heavy imports until execution time."""
+
+    from .assistant import main as _main
+
+    return _main(list(argv) if argv is not None else None)
+
+
+__all__ = ["main"]

--- a/src/alloy_assistant/__main__.py
+++ b/src/alloy_assistant/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running ``python -m alloy_assistant`` to launch the assistant."""
+
+from .assistant import main
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    raise SystemExit(main())

--- a/src/alloy_assistant/assistant.py
+++ b/src/alloy_assistant/assistant.py
@@ -1,0 +1,137 @@
+"""Interactive CLI entry point for the alloy-inspired voice assistant."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from .audio import (
+    AudioPlaybackError,
+    AudioPlayer,
+    MicrophoneUnavailableError,
+    VoiceRecorder,
+)
+from .client import OpenAIClient, build_messages
+from .config import Settings
+from .conversation import ConversationMemory
+
+
+def _format_header() -> str:
+    banner = r"""
+     ___    _ _                   __     __           _           _   _              _   _             _
+    / _ \__| (_)_ __   ___ _   _  \ \   / /__ _ __ __| | ___ _ __ | |_(_) ___  ___  | | | |_   _  __ _| |_ ___
+   / /_\/ _` | | '_ \ / _ \ | | |  \ \ / / _ \ '__/ _` |/ _ \ '_ \| __| |/ _ \/ __| | |_| | | | |/ _` | __/ _ \
+  / /_\\ (_| | | | | |  __/ |_| |   \ V /  __/ | | (_| |  __/ | | | |_| |  __/\__ \ |  _  | |_| | (_| | ||  __/
+  \____/\__,_|_|_| |_|\___|\__,_|    \_/ \___|_|  \__,_|\___|_| |_|\__|_|\___||___/ |_| |_|\__,_|\__,_|\__\___|
+    """
+    return textwrap.dedent(banner).strip("\n")
+
+
+@contextmanager
+def _timer() -> Iterator[Callable[[], float]]:  # pragma: no cover - used for CLI reporting
+    start = time.perf_counter()
+    yield lambda: time.perf_counter() - start
+
+
+def run(settings: Settings) -> int:
+    """Run the interactive assistant loop."""
+
+    try:
+        client = OpenAIClient(settings)
+    except RuntimeError as exc:  # pragma: no cover - runtime dependency check
+        print(f"Unable to start assistant: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        recorder = VoiceRecorder(settings)
+    except MicrophoneUnavailableError as exc:  # pragma: no cover - runtime dependency check
+        print(f"Unable to access microphone: {exc}", file=sys.stderr)
+        return 1
+
+    player = AudioPlayer()
+    memory = ConversationMemory(max_messages=settings.conversation_window)
+
+    print("Press Enter to speak. Type 'quit' to exit.")
+
+    while True:
+        user_input = input("\n▶  ").strip()
+        if user_input.lower() in {"quit", "exit", "q"}:
+            print("Goodbye! 👋")
+            return 0
+        if user_input:
+            print("Type Enter without text to record audio.")
+            continue
+
+        print("Listening... (speak clearly into your microphone)")
+
+        with _timer() as elapsed:
+            recording = recorder.record()
+        if recording is None:
+            print("No audio captured. Try speaking louder or adjusting the microphone.")
+            continue
+
+        print(f"Captured {recording.duration:.1f}s of audio in {elapsed():.2f}s. Transcribing...")
+
+        with _timer() as elapsed:
+            transcript = client.transcribe(recording.audio)
+        if not transcript:
+            print("I couldn't understand that. Let's try again.")
+            continue
+
+        print(f"You said: {transcript}")
+        with _timer() as elapsed:
+            messages = build_messages(settings, memory.as_pairs(), transcript)
+            response = client.complete(messages)
+        if not response.text:
+            print("I didn't get a response from the model. Please try again.")
+            continue
+
+        print(f"Alloy: {response.text}")
+        memory.add("user", transcript)
+        memory.add("assistant", response.text)
+
+        if response.audio and player.available:
+            try:
+                player.play(response.audio)
+            except AudioPlaybackError as exc:  # pragma: no cover - optional runtime dependency
+                print(f"Audio playback failed: {exc}")
+
+        print(f"⏱️  Response latency: {elapsed():.2f}s")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description="Run the Alloy-inspired voice assistant")
+    parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        help="Hide the ASCII art banner on startup.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Module entry point used by :mod:`python -m alloy_assistant`."""
+
+    args = parse_args(argv)
+
+    try:
+        settings = Settings.from_env()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if not args.no_banner:
+        print(_format_header())
+        print()
+
+    return run(settings)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    raise SystemExit(main())

--- a/src/alloy_assistant/audio.py
+++ b/src/alloy_assistant/audio.py
@@ -1,0 +1,181 @@
+"""Audio utilities for recording microphone input and playing synthesized speech."""
+
+from __future__ import annotations
+
+import io
+import math
+import queue
+import tempfile
+from dataclasses import dataclass
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency for runtime execution
+    import sounddevice as sd
+except Exception:  # pragma: no cover
+    sd = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency for runtime execution
+    import simpleaudio  # noqa: WPS433 (third-party import only when available)
+except Exception:  # pragma: no cover
+    simpleaudio = None  # type: ignore
+
+import wave
+
+from .config import Settings
+
+
+class MicrophoneUnavailableError(RuntimeError):
+    """Raised when :mod:`sounddevice` is not available."""
+
+
+class AudioPlaybackError(RuntimeError):
+    """Raised when :mod:`simpleaudio` is not installed or playback fails."""
+
+
+@dataclass(slots=True)
+class RecordingResult:
+    """Container for recorded audio."""
+
+    audio: bytes
+    duration: float
+
+
+class VoiceRecorder:
+    """Capture audio from the system microphone with basic VAD controls."""
+
+    def __init__(self, settings: Settings) -> None:
+        if sd is None:  # pragma: no cover - dependent on optional runtime dependency
+            raise MicrophoneUnavailableError(
+                "sounddevice is required for recording audio. Install optional dependencies "
+                "or run the project on a machine with microphone support."
+            )
+
+        self.settings = settings
+        self._queue: queue.Queue[np.ndarray] = queue.Queue()
+        self._block_size = int(settings.sample_rate * settings.block_duration)
+        self._silence_samples = int(settings.max_silence_seconds / settings.block_duration)
+
+    def record(self) -> RecordingResult | None:
+        """Record a single utterance from the microphone.
+
+        The recorder collects audio chunks until it detects a sufficient amount of
+        silence or the configured maximum duration is reached. The raw audio is
+        returned as a WAV byte sequence alongside the captured duration.
+        """
+
+        frames: list[np.ndarray] = []
+        silence_streak = 0
+        captured_blocks = 0
+
+        def _callback(indata: np.ndarray, frames: int, time, status) -> None:  # pragma: no cover - callback invoked by sounddevice
+            if status:
+                # Drop frames with errors to keep the buffer in sync.
+                return
+            self._queue.put_nowait(indata.copy())
+
+        with sd.InputStream(
+            samplerate=self.settings.sample_rate,
+            channels=self.settings.channels,
+            dtype=self.settings.dtype,
+            blocksize=self._block_size,
+            callback=_callback,
+        ):
+            max_blocks = math.ceil(
+                self.settings.max_recording_seconds / self.settings.block_duration
+            )
+            min_blocks = max(
+                1, math.ceil(self.settings.min_recording_seconds / self.settings.block_duration)
+            )
+
+            while captured_blocks < max_blocks:
+                try:
+                    chunk = self._queue.get(timeout=1.0)
+                except queue.Empty:
+                    continue
+
+                frames.append(chunk)
+                captured_blocks += 1
+
+                rms = float(np.sqrt(np.mean(np.square(chunk))))
+                if rms < self.settings.silence_threshold:
+                    silence_streak += 1
+                else:
+                    silence_streak = 0
+
+                if captured_blocks >= min_blocks and silence_streak >= self._silence_samples:
+                    break
+
+        if not frames:
+            return None
+
+        audio = np.concatenate(frames, axis=0)
+        duration = len(audio) / float(self.settings.sample_rate)
+
+        # Convert to int16 PCM for compatibility with OpenAI endpoints.
+        audio = np.clip(audio, -1.0, 1.0)
+        pcm_data = (audio * np.iinfo(np.int16).max).astype(np.int16)
+
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(self.settings.channels)
+            wav_file.setsampwidth(2)  # 16-bit PCM
+            wav_file.setframerate(self.settings.sample_rate)
+            wav_file.writeframes(pcm_data.tobytes())
+
+        return RecordingResult(audio=buffer.getvalue(), duration=duration)
+
+
+class AudioPlayer:
+    """Simple WAV playback helper using :mod:`simpleaudio`."""
+
+    def __init__(self) -> None:
+        if simpleaudio is None:  # pragma: no cover - optional runtime dependency
+            self._enabled = False
+        else:
+            self._enabled = True
+
+    @property
+    def available(self) -> bool:
+        """Return ``True`` when playback dependencies are installed."""
+
+        return self._enabled
+
+    def play(self, wav_audio: bytes) -> None:
+        """Play a short WAV clip from memory."""
+
+        if not self._enabled:
+            raise AudioPlaybackError(
+                "simpleaudio is required for playback. Install optional dependencies to "
+                "hear Alloy's responses or disable audio playback."
+            )
+
+        with wave.open(io.BytesIO(wav_audio), "rb") as wav_file:
+            audio_data = wav_file.readframes(wav_file.getnframes())
+            wave_object = simpleaudio.WaveObject(
+                audio_data,
+                num_channels=wav_file.getnchannels(),
+                bytes_per_sample=wav_file.getsampwidth(),
+                sample_rate=wav_file.getframerate(),
+            )
+
+        play_obj = wave_object.play()
+        play_obj.wait_done()
+
+
+def save_wav_to_temp_file(data: bytes, suffix: str = ".wav") -> str:
+    """Persist audio bytes to a temporary file and return the path."""
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(data)
+        return tmp.name
+
+
+__all__ = [
+    "AudioPlayer",
+    "AudioPlaybackError",
+    "MicrophoneUnavailableError",
+    "RecordingResult",
+    "VoiceRecorder",
+    "save_wav_to_temp_file",
+]

--- a/src/alloy_assistant/client.py
+++ b/src/alloy_assistant/client.py
@@ -1,0 +1,174 @@
+"""OpenAI API client wrappers used by the voice assistant."""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency for runtime execution
+    from openai import OpenAI
+    from openai.types.chat import ChatCompletionMessageParam
+except Exception:  # pragma: no cover
+    OpenAI = None  # type: ignore
+    ChatCompletionMessageParam = dict  # type: ignore
+
+from .config import Settings
+
+
+@dataclass(slots=True)
+class ChatResult:
+    """Container for assistant responses."""
+
+    text: str
+    audio: bytes | None = None
+
+
+class OpenAIClient:
+    """Small convenience wrapper around the official OpenAI Python SDK."""
+
+    def __init__(self, settings: Settings) -> None:
+        if OpenAI is None:  # pragma: no cover - optional runtime dependency
+            raise RuntimeError(
+                "The `openai` package is required to run the assistant. Install the project "
+                "dependencies (pip install -e .) before launching the app."
+            )
+
+        self.settings = settings
+        self._client = OpenAI(api_key=settings.openai_api_key)
+
+    def transcribe(self, wav_audio: bytes) -> str:
+        """Send audio to OpenAI and return the transcription text."""
+
+        audio_buffer = io.BytesIO(wav_audio)
+        audio_buffer.name = "speech.wav"  # type: ignore[attr-defined]
+
+        transcription = self._client.audio.transcriptions.create(  # type: ignore[no-untyped-call]
+            model=self.settings.transcription_model,
+            file=audio_buffer,
+        )
+        text = getattr(transcription, "text", "")
+        return text.strip()
+
+    def complete(self, messages: Sequence[ChatCompletionMessageParam]) -> ChatResult:
+        """Request a textual response and optional synthesized audio."""
+
+        response = self._client.responses.create(  # type: ignore[no-untyped-call]
+            model=self.settings.model,
+            input=list(messages),
+            audio={"voice": self.settings.voice, "format": "wav"},
+        )
+
+        text_fragments: list[str] = []
+        audio_bytes: bytes | None = None
+
+        for item in getattr(response, "output", []):
+            contents = getattr(item, "content", [])
+            for content in contents:
+                content_type = getattr(content, "type", None)
+                if content_type == "output_text":
+                    text_fragments.append(getattr(content, "text", ""))
+                elif content_type == "output_audio" and audio_bytes is None:
+                    audio = getattr(content, "audio", None)
+                    if audio is None:
+                        continue
+                    data = getattr(audio, "data", None)
+                    if isinstance(data, str):
+                        try:
+                            audio_bytes = base64.b64decode(data)
+                        except Exception:  # pragma: no cover - defensive branch
+                            audio_bytes = None
+
+        text = "".join(text_fragments).strip()
+        if audio_bytes is None and text:
+            audio_bytes = self._synthesize_text(text)
+
+        return ChatResult(text=text, audio=audio_bytes)
+
+    def _synthesize_text(self, text: str) -> bytes | None:
+        """Fallback TTS helper used when the responses API does not return audio."""
+
+        if not text:
+            return None
+
+        try:
+            with self._client.audio.speech.with_streaming_response.create(  # type: ignore[no-untyped-call]
+                model=self.settings.tts_model,
+                voice=self.settings.voice,
+                input=text,
+                format="wav",
+            ) as response:
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                    response.stream_to_file(tmp.name)
+                    tmp.seek(0)
+                    data = tmp.read()
+            os.unlink(tmp.name)
+            return data
+        except AttributeError:  # pragma: no cover - fallback for older SDK versions
+            speech = self._client.audio.speech.create(  # type: ignore[no-untyped-call]
+                model=self.settings.tts_model,
+                voice=self.settings.voice,
+                input=text,
+                format="wav",
+            )
+            audio = getattr(speech, "audio", None)
+            if isinstance(audio, bytes):
+                return audio
+            data = getattr(speech, "data", None)
+            if isinstance(data, str):
+                try:
+                    return base64.b64decode(data)
+                except Exception:  # pragma: no cover - defensive branch
+                    return None
+            if hasattr(speech, "read"):
+                return speech.read()
+            return None
+
+
+def build_messages(settings: Settings, history: Iterable[tuple[str, str]], user_text: str) -> list[ChatCompletionMessageParam]:
+    """Assemble messages for the Responses API."""
+
+    messages: list[ChatCompletionMessageParam] = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": settings.system_prompt,
+                }
+            ],
+        }
+    ]
+
+    for role, content in history:
+        messages.append(
+            {
+                "role": role,
+                "content": [
+                    {
+                        "type": "text",
+                        "text": content,
+                    }
+                ],
+            }
+        )
+
+    messages.append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": user_text,
+                }
+            ],
+        }
+    )
+
+    return messages
+
+
+__all__ = ["ChatResult", "OpenAIClient", "build_messages"]

--- a/src/alloy_assistant/config.py
+++ b/src/alloy_assistant/config.py
@@ -1,0 +1,132 @@
+"""Configuration helpers for the alloy-inspired voice assistant."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
+DEFAULT_TTS_MODEL = "gpt-4o-mini-tts"
+DEFAULT_VOICE = "alloy"
+DEFAULT_SYSTEM_PROMPT = (
+    "You are Alloy, a helpful, proactive voice assistant that keeps responses concise "
+    "and conversational. Provide practical answers and optional follow up suggestions."
+)
+DEFAULT_SAMPLE_RATE = 16_000
+DEFAULT_CHANNELS = 1
+DEFAULT_DTYPE = "float32"
+DEFAULT_BLOCK_DURATION = 0.5
+DEFAULT_SILENCE_THRESHOLD = 0.015
+DEFAULT_MAX_SILENCE_SECONDS = 1.5
+DEFAULT_MAX_RECORDING_SECONDS = 30.0
+DEFAULT_MIN_RECORDING_SECONDS = 0.4
+DEFAULT_CONVERSATION_WINDOW = 8
+
+
+@dataclass(slots=True)
+class Settings:
+    """Application settings loaded from the environment."""
+
+    openai_api_key: str
+    model: str = DEFAULT_MODEL
+    transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
+    tts_model: str = DEFAULT_TTS_MODEL
+    voice: str = DEFAULT_VOICE
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT
+    sample_rate: int = DEFAULT_SAMPLE_RATE
+    channels: int = DEFAULT_CHANNELS
+    dtype: str = DEFAULT_DTYPE
+    block_duration: float = DEFAULT_BLOCK_DURATION
+    silence_threshold: float = DEFAULT_SILENCE_THRESHOLD
+    max_silence_seconds: float = DEFAULT_MAX_SILENCE_SECONDS
+    max_recording_seconds: float = DEFAULT_MAX_RECORDING_SECONDS
+    min_recording_seconds: float = DEFAULT_MIN_RECORDING_SECONDS
+    conversation_window: int = DEFAULT_CONVERSATION_WINDOW
+
+    @classmethod
+    def from_env(cls, env: Optional[dict[str, str]] = None) -> "Settings":
+        """Create settings from the process environment.
+
+        Parameters
+        ----------
+        env:
+            Optional mapping used instead of :data:`os.environ` for testing.
+
+        Returns
+        -------
+        Settings
+            Populated configuration dataclass.
+
+        Raises
+        ------
+        RuntimeError
+            If the OpenAI API key is missing.
+        """
+
+        env_map = dict(os.environ if env is None else env)
+
+        api_key = env_map.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is required to run the voice assistant."
+            )
+
+        def _float(name: str, default: float) -> float:
+            value = env_map.get(name)
+            if value is None:
+                return default
+            try:
+                return float(value)
+            except ValueError:
+                return default
+
+        def _int(name: str, default: int) -> int:
+            value = env_map.get(name)
+            if value is None:
+                return default
+            try:
+                return int(value)
+            except ValueError:
+                return default
+
+        return cls(
+            openai_api_key=api_key,
+            model=env_map.get("ALLOY_MODEL", DEFAULT_MODEL),
+            transcription_model=env_map.get(
+                "ALLOY_TRANSCRIPTION_MODEL", DEFAULT_TRANSCRIPTION_MODEL
+            ),
+            tts_model=env_map.get("ALLOY_TTS_MODEL", DEFAULT_TTS_MODEL),
+            voice=env_map.get("ALLOY_VOICE", DEFAULT_VOICE),
+            system_prompt=env_map.get("ALLOY_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT),
+            sample_rate=_int("ALLOY_SAMPLE_RATE", DEFAULT_SAMPLE_RATE),
+            channels=_int("ALLOY_CHANNELS", DEFAULT_CHANNELS),
+            dtype=env_map.get("ALLOY_DTYPE", DEFAULT_DTYPE),
+            block_duration=_float("ALLOY_BLOCK_DURATION", DEFAULT_BLOCK_DURATION),
+            silence_threshold=_float(
+                "ALLOY_SILENCE_THRESHOLD", DEFAULT_SILENCE_THRESHOLD
+            ),
+            max_silence_seconds=_float(
+                "ALLOY_MAX_SILENCE", DEFAULT_MAX_SILENCE_SECONDS
+            ),
+            max_recording_seconds=_float(
+                "ALLOY_MAX_RECORDING", DEFAULT_MAX_RECORDING_SECONDS
+            ),
+            min_recording_seconds=_float(
+                "ALLOY_MIN_RECORDING", DEFAULT_MIN_RECORDING_SECONDS
+            ),
+            conversation_window=_int(
+                "ALLOY_CONVERSATION_WINDOW", DEFAULT_CONVERSATION_WINDOW
+            ),
+        )
+
+
+__all__ = [
+    "Settings",
+    "DEFAULT_MODEL",
+    "DEFAULT_TRANSCRIPTION_MODEL",
+    "DEFAULT_TTS_MODEL",
+    "DEFAULT_VOICE",
+    "DEFAULT_SYSTEM_PROMPT",
+]

--- a/src/alloy_assistant/conversation.py
+++ b/src/alloy_assistant/conversation.py
@@ -1,0 +1,49 @@
+"""Conversation history helpers for the voice assistant."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Iterator
+
+Role = str
+
+
+@dataclass(slots=True)
+class Message:
+    """Simple message container."""
+
+    role: Role
+    content: str
+
+
+class ConversationMemory:
+    """Maintain a rolling window of the conversation with the assistant."""
+
+    def __init__(self, max_messages: int) -> None:
+        if max_messages <= 0:
+            raise ValueError("max_messages must be greater than zero")
+        self._messages: Deque[Message] = deque(maxlen=max_messages)
+
+    def add(self, role: Role, content: str) -> None:
+        """Append a new message to the history."""
+
+        cleaned = content.strip()
+        if not cleaned:
+            return
+        self._messages.append(Message(role=role, content=cleaned))
+
+    def as_pairs(self) -> Iterator[tuple[Role, str]]:
+        """Yield history entries as ``(role, content)`` tuples."""
+
+        for message in self._messages:
+            yield message.role, message.content
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._messages)
+
+    def __iter__(self) -> Iterator[Message]:  # pragma: no cover - trivial
+        return iter(self._messages)
+
+
+__all__ = ["ConversationMemory", "Message", "Role"]

--- a/tests/test_client_messages.py
+++ b/tests/test_client_messages.py
@@ -1,0 +1,31 @@
+"""Unit tests for the message builder helper."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from alloy_assistant.client import build_messages
+from alloy_assistant.config import Settings
+
+
+class BuildMessagesTests(unittest.TestCase):
+    def test_includes_history_and_new_prompt(self) -> None:
+        env = {"OPENAI_API_KEY": "test"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            settings = Settings.from_env()
+
+        history = [("user", "hello"), ("assistant", "hi")]
+        messages = build_messages(settings, history, "How are you?")
+
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertEqual(messages[1]["content"][0]["text"], "hello")
+        self.assertEqual(messages[2]["role"], "assistant")
+        self.assertEqual(messages[-1]["role"], "user")
+        self.assertEqual(messages[-1]["content"][0]["text"], "How are you?")
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest runner
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,50 @@
+"""Unit tests for configuration helpers using :mod:`unittest`."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from alloy_assistant.config import (
+    DEFAULT_MODEL,
+    DEFAULT_SYSTEM_PROMPT,
+    Settings,
+)
+
+
+class SettingsTests(unittest.TestCase):
+    """Verify environment parsing logic."""
+
+    def test_defaults(self) -> None:
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True):
+            settings = Settings.from_env()
+
+        self.assertEqual(settings.openai_api_key, "test-key")
+        self.assertEqual(settings.model, DEFAULT_MODEL)
+        self.assertEqual(settings.system_prompt, DEFAULT_SYSTEM_PROMPT)
+        self.assertEqual(settings.sample_rate, 16_000)
+
+    def test_overrides(self) -> None:
+        env = {
+            "OPENAI_API_KEY": "override-key",
+            "ALLOY_MODEL": "test-model",
+            "ALLOY_SAMPLE_RATE": "22050",
+            "ALLOY_BLOCK_DURATION": "0.1",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            settings = Settings.from_env()
+
+        self.assertEqual(settings.openai_api_key, "override-key")
+        self.assertEqual(settings.model, "test-model")
+        self.assertEqual(settings.sample_rate, 22050)
+        self.assertAlmostEqual(settings.block_duration, 0.1)
+
+    def test_missing_api_key(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                Settings.from_env()
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest runner
+    unittest.main()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,43 @@
+"""Unit tests for the conversation memory helper."""
+
+from __future__ import annotations
+
+import unittest
+
+from alloy_assistant.conversation import ConversationMemory
+
+
+class ConversationMemoryTests(unittest.TestCase):
+    def test_preserves_latest_messages(self) -> None:
+        memory = ConversationMemory(max_messages=3)
+
+        memory.add("user", "hello")
+        memory.add("assistant", "hi there")
+        memory.add("user", "what's the weather?")
+        memory.add("assistant", "It's sunny!")
+
+        history = list(memory.as_pairs())
+        self.assertEqual(
+            history,
+            [
+                ("assistant", "hi there"),
+                ("user", "what's the weather?"),
+                ("assistant", "It's sunny!"),
+            ],
+        )
+
+    def test_ignores_empty_messages(self) -> None:
+        memory = ConversationMemory(max_messages=2)
+
+        memory.add("user", "   ")
+        memory.add("assistant", "Sure!")
+
+        self.assertEqual(list(memory.as_pairs()), [("assistant", "Sure!")])
+
+    def test_requires_positive_window(self) -> None:
+        with self.assertRaises(ValueError):
+            ConversationMemory(max_messages=0)
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest runner
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python package that wraps OpenAI transcription, reasoning, and text-to-speech APIs behind a conversational CLI
- implement microphone recording, playback, configuration, and message-memory helpers inspired by the alloy voice assistant
- document setup and usage while adding unit tests for the configuration, message builder, and conversation memory utilities

## Testing
- python -m unittest discover -s tests
- python -m compileall src tests

------
https://chatgpt.com/codex/tasks/task_e_68c931ad7dcc833381965c43048cabc9